### PR TITLE
docs: use dbitemplate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     DBItest (>= 1.8.0)
 Remotes: 
     r-dbi/DBI
-Config/Needs/website: maelle/dbitemplate
+Config/Needs/website: r-dbi/dbitemplate
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Suggests:
     DBItest (>= 1.8.0)
 Remotes: 
     r-dbi/DBI
+Config/Needs/website: maelle/dbitemplate
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,8 +1,7 @@
-url: https://rkazamg s.r-dbi.org
+url: ~
 
 template:
-  params:
-    bootswatch: flatly # https://bootswatch.com/flatly/
+  package: dbitemplate
 
 home:
   links:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: ~
+url: https://rkazam.r-dbi.org
 
 template:
   package: dbitemplate


### PR DESCRIPTION
The URL actually doesn't exist.

I won't do more such PRs before dbitemplate lives in its final home, otherwise I'll have to update all the DESCRIPTION files again.